### PR TITLE
--run-as parameter for Bolt

### DIFF
--- a/steps/run/spec.schema.json
+++ b/steps/run/spec.schema.json
@@ -54,6 +54,10 @@
           "type": "string",
           "description": "The name of a key in the `credentials` setting to use as the default SSH private key."
         },
+        "run_as": {
+          "type": "string",
+          "description": "The username to use to run the task/plan"
+        },
         "useSSL": {
           "type": "boolean",
           "description": "If using the WinRM transport, whether to use SSL to connect.",

--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -77,6 +77,9 @@ TRANSPORT_USER="$( $NI get -p '{ .transport.user }' )"
 TRANSPORT_PASSWORD="$( $NI get -p '{ .transport.password }' )"
 [ -n "${TRANSPORT_PASSWORD}" ] && BOLT_ARGS+=( "--password=${TRANSPORT_PASSWORD}" )
 
+TRANSPORT_RUN_AS="$( $NI get -p '{ .transport.run_as }' )"
+[ -n "${TRANSPORT_RUN_AS}" ] && BOLT_ARGS+=( "--run-as=${TRANSPORT_RUN_AS}" )
+
 case "${TRANSPORT_TYPE}" in
 ssh)
   TRANSPORT_PRIVATE_KEY="$( $NI get -p '{ .transport.privateKey }' )"


### PR DESCRIPTION
Added an option to the transport section that allows you to specify the --run-as Bolt paramater