### PR TITLE
fixed a bug with the installation of Puppet modules

### DIFF
--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -117,7 +117,7 @@ TARGETS="$( $NI get | $JQ -r 'try .targets | if type == "string" then . else joi
 
 INSTALL_MODULES="$( $NI get -p '{ .installModules }' )"
 if [[ "${INSTALL_MODULES}" == "true" ]]; then
-    $BOLT puppetfile install "${BOLT_ARGS[@]}"
+    $BOLT module install "${BOLT_ARGS[@]}"
 fi
 
 echo "Running command: $BOLT ${BOLT_TYPE} run ${BOLT_NAME} ${BOLT_ARGS[@]}"


### PR DESCRIPTION
The command 'bolt puppetfile install' doesn't exist. The correct command is 'bolt module install'.