### PR TITLE
Use of git connection and fix for bolt error

### DIFF
--- a/steps/run/spec.schema.json
+++ b/steps/run/spec.schema.json
@@ -86,38 +86,6 @@
       "type": "object",
       "description": "A map of git configuration. If you're using HTTPS, only name and repository are required.",
       "properties": {
-        "ssh_key": {
-          "type": "string",
-          "description": "The SSH key to use when cloning the git repository. You can pass the key to Relay as a secret."
-        },
-        "known_hosts": {
-          "type": "string",
-          "description": "SSH known hosts file. Use a Relay secret to pass the contents of the file into the workflow as a base64-encoded string."
-        },
-        "name": {
-          "type": "string",
-          "description": "A directory name for the git clone."
-        },
-        "branch": {
-          "type": "string",
-          "description": "The Git branch to clone.",
-          "default": "master"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The git repository URL."
-        }
-      },
-      "required": [
-        "ssh_key",
-        "name",
-        "repository"
-      ]
-    },
-    "git_connection": {
-      "type": "object",
-      "description": "A map of git configuration. If you're using HTTPS, only name and repository are required.",
-      "properties": {
         "connection": {
           "type": "object",
           "x-relay-connectionType": "ssh",

--- a/steps/run/spec.schema.json
+++ b/steps/run/spec.schema.json
@@ -86,6 +86,38 @@
       "type": "object",
       "description": "A map of git configuration. If you're using HTTPS, only name and repository are required.",
       "properties": {
+        "ssh_key": {
+          "type": "string",
+          "description": "The SSH key to use when cloning the git repository. You can pass the key to Relay as a secret."
+        },
+        "known_hosts": {
+          "type": "string",
+          "description": "SSH known hosts file. Use a Relay secret to pass the contents of the file into the workflow as a base64-encoded string."
+        },
+        "name": {
+          "type": "string",
+          "description": "A directory name for the git clone."
+        },
+        "branch": {
+          "type": "string",
+          "description": "The Git branch to clone.",
+          "default": "master"
+        },
+        "repository": {
+          "type": "string",
+          "description": "The git repository URL."
+        }
+      },
+      "required": [
+        "ssh_key",
+        "name",
+        "repository"
+      ]
+    },
+    "git_connection": {
+      "type": "object",
+      "description": "A map of git configuration. If you're using HTTPS, only name and repository are required.",
+      "properties": {
         "connection": {
           "type": "object",
           "x-relay-connectionType": "ssh",

--- a/steps/run/spec.schema.json
+++ b/steps/run/spec.schema.json
@@ -86,9 +86,16 @@
       "type": "object",
       "description": "A map of git configuration. If you're using HTTPS, only name and repository are required.",
       "properties": {
-        "ssh_key": {
-          "type": "string",
-          "description": "The SSH key to use when cloning the git repository. You can pass the key to Relay as a secret."
+        "connection": {
+          "type": "object",
+          "x-relay-connectionType": "ssh",
+          "description": "A Relay SSH connection to use",
+          "properties": {
+            "sshKey": {
+              "type": "string",
+              "description": "The SSH key to use when cloning the git repository."
+            }
+          }
         },
         "known_hosts": {
           "type": "string",

--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -125,4 +125,10 @@ echo "Running command: $BOLT ${BOLT_TYPE} run ${BOLT_NAME} ${BOLT_ARGS[@]}"
 # Run Bolt!
 BOLT_OUTPUT=$($BOLT "${BOLT_TYPE}" run "${BOLT_NAME}" "${BOLT_ARGS[@]}")
 
+# Make the step fail if the Bolt command returns non-zero exit code
+if [[ $? -ne 0 ]]; then
+    echo "$BOLT_OUTPUT"
+    exit 1
+fi
+
 $NI output set --key output --value "$BOLT_OUTPUT" --json

--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -55,22 +55,10 @@ PARAMS="$( $NI get | jq 'try .parameters // empty' )"
 [ -n "${PARAMS}" ] && BOLT_ARGS+=( "--params=${PARAMS}" )
 
 # Boltdir configuration
-if [ -n "$( $NI get -p '{ .git.repository }' )" ]; then
-  $NI git clone -d "${WORKDIR}/repo" || ni log fatal 'could not clone Git repository'
-
-  PROJECT_DIR="$( $NI get -p '{ .projectDir }' )"
-  BOLTDIR="${WORKDIR}/repo/$( $NI get -p '{ .git.name }' )${PROJECT_DIR+"/${PROJECT_DIR}"}"
-  [ ! -d "${BOLTDIR}" ] && ni log fatal "Bolt project directory \"${BOLTDIR}\" does not exist"
-
-  BOLT_ARGS+=( "--project=${BOLTDIR}" )
-elif [ -n "$( $NI get -p '{ .projectDir}' )" ]; then
-  usage 'spec: only specify `projectDir` if you have specified a Git repository in `git`'
-fi
-
-GIT=$(ni get -p {.git_connection})
+GIT=$(ni get -p {.git})
 if [ -n "${GIT}" ]; then
   ni git clone
-  NAME=$(ni get -p {.git_connection.name})
+  NAME=$(ni get -p {.git.name})
   PROJECT_DIR="$( $NI get -p '{ .projectDir }' )"
   BOLTDIR="/workspace/${NAME}/${PROJECT_DIR}"
   BOLT_ARGS+=( "--project=${BOLTDIR}" )

--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -64,19 +64,6 @@ if [ -n "${GIT}" ]; then
   BOLT_ARGS+=( "--project=${BOLTDIR}" )
 fi
 
-
-# if [ -n "$( $NI get -p '{ .git.repository }' )" ]; then
-#   $NI git clone -d "${WORKDIR}/repo" || ni log fatal 'could not clone Git repository'
-
-#   PROJECT_DIR="$( $NI get -p '{ .projectDir }' )"
-#   BOLTDIR="${WORKDIR}/repo/$( $NI get -p '{ .git.name }' )${PROJECT_DIR+"/${PROJECT_DIR}"}"
-#   [ ! -d "${BOLTDIR}" ] && ni log fatal "Bolt project directory \"${BOLTDIR}\" does not exist"
-
-#   BOLT_ARGS+=( "--project=${BOLTDIR}" )
-# elif [ -n "$( $NI get -p '{ .projectDir}' )" ]; then
-#   usage 'spec: only specify `projectDir` if you have specified a Git repository in `git`'
-# fi
-
 MODULE_PATH="$( $NI get | $JQ -r 'try .modulePaths | join(":")' )"
 [ -n "${MODULE_PATH}" ] && BOLT_ARGS+=( "--modulepath=${MODULE_PATH}" )
 

--- a/steps/run/step.sh
+++ b/steps/run/step.sh
@@ -55,17 +55,27 @@ PARAMS="$( $NI get | jq 'try .parameters // empty' )"
 [ -n "${PARAMS}" ] && BOLT_ARGS+=( "--params=${PARAMS}" )
 
 # Boltdir configuration
-if [ -n "$( $NI get -p '{ .git.repository }' )" ]; then
-  $NI git clone -d "${WORKDIR}/repo" || ni log fatal 'could not clone Git repository'
-
+GIT=$(ni get -p {.git})
+if [ -n "${GIT}" ]; then
+  ni git clone
+  NAME=$(ni get -p {.git.name})
   PROJECT_DIR="$( $NI get -p '{ .projectDir }' )"
-  BOLTDIR="${WORKDIR}/repo/$( $NI get -p '{ .git.name }' )${PROJECT_DIR+"/${PROJECT_DIR}"}"
-  [ ! -d "${BOLTDIR}" ] && ni log fatal "Bolt project directory \"${BOLTDIR}\" does not exist"
-
+  BOLTDIR="/workspace/${NAME}/${PROJECT_DIR}"
   BOLT_ARGS+=( "--project=${BOLTDIR}" )
-elif [ -n "$( $NI get -p '{ .projectDir}' )" ]; then
-  usage 'spec: only specify `projectDir` if you have specified a Git repository in `git`'
 fi
+
+
+# if [ -n "$( $NI get -p '{ .git.repository }' )" ]; then
+#   $NI git clone -d "${WORKDIR}/repo" || ni log fatal 'could not clone Git repository'
+
+#   PROJECT_DIR="$( $NI get -p '{ .projectDir }' )"
+#   BOLTDIR="${WORKDIR}/repo/$( $NI get -p '{ .git.name }' )${PROJECT_DIR+"/${PROJECT_DIR}"}"
+#   [ ! -d "${BOLTDIR}" ] && ni log fatal "Bolt project directory \"${BOLTDIR}\" does not exist"
+
+#   BOLT_ARGS+=( "--project=${BOLTDIR}" )
+# elif [ -n "$( $NI get -p '{ .projectDir}' )" ]; then
+#   usage 'spec: only specify `projectDir` if you have specified a Git repository in `git`'
+# fi
 
 MODULE_PATH="$( $NI get | $JQ -r 'try .modulePaths | join(":")' )"
 [ -n "${MODULE_PATH}" ] && BOLT_ARGS+=( "--modulepath=${MODULE_PATH}" )


### PR DESCRIPTION
In this pull request I changed the git connection to work like it does in the Terraform steps. I found that working with a connection is far easier to maintain then having to provide a ssh key in every step.

Next to that I also fixed an issue where the Relay step would not fail, even though the bolt command returned a non-zero exit code.

Let me know if you have any questions/remarks!